### PR TITLE
Pass AuthenticatedVRC's ApiError instead of panicing with unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ percent-encoding = { version = "2", optional = true }
 base64 = { version = "0.21", optional = true }
 
 async-trait = { version = "0.1", optional = true }
-either = { version = "1", features = ["serde"] }
+# either = { version = "1", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
 [dependencies.reqwest]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,26 +25,23 @@ default = []
 api_client = ["racal/reqwest", "reqwest", "governor", "percent-encoding", "base64", "async-trait"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_with = { version = "2.1", features = ["time_0_3"] }
-time = { version = "0.3", default-features = false, features = [
-	"macros",
-	"serde-well-known",
-] }
+serde = { version = "1", features = ["derive"] }
+serde_with = { version = "3", features = ["time_0_3"] }
+time = { version = "0.3", default-features = false, features = ["macros", "serde-well-known"] }
 serde_json = { version = "1" }
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 
 # API client specifics
-racal = "0.3.3"
-#racal = { path = "../racal" }
-governor = { version = "0.5", optional = true }
-tokio = { version = "1", optional = true}
-percent-encoding  = { version = "2.2", optional = true}
-base64  = { version = "0.21", optional = true}
+racal = "0.3"
+# racal = { path = "../racal" }
+governor = { version = "0.6", optional = true }
+tokio = { version = "1", optional = true }
+percent-encoding = { version = "2", optional = true }
+base64 = { version = "0.21", optional = true }
 
 async-trait = { version = "0.1", optional = true }
-either = { version = "1.8.1", features = ["serde"] }
-url = { version = "2.3.1", features = ["serde"] }
+either = { version = "1", features = ["serde"] }
+url = { version = "2", features = ["serde"] }
 [dependencies.reqwest]
 optional = true
 version = "0.11"
@@ -53,8 +50,8 @@ features = ["json", "rustls-tls"]
 
 [dev-dependencies]
 tokio-test = "0.4"
-tokio = { version = "1", features = ["rt", "macros"]}
-once_cell = "1.17"
+tokio = { version = "1", features = ["rt", "macros"] }
+once_cell = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/deny.toml
+++ b/deny.toml
@@ -59,7 +59,7 @@ unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = ["MIT", "ISC", "Apache-2.0", "MPL-2.0", "BSD-3-Clause", "BSD-2-Clause",  "OpenSSL", "Unicode-DFS-2016"]
+allow = ["MIT", "ISC", "Apache-2.0", "MPL-2.0", "BSD-3-Clause", "BSD-2-Clause", "OpenSSL", "Unicode-DFS-2016"]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].

--- a/src/model/users.rs
+++ b/src/model/users.rs
@@ -1,4 +1,3 @@
-use either::Either;
 use serde::{Deserialize, Serialize};
 use time::{serde::rfc3339, OffsetDateTime};
 use url::Url;

--- a/src/model/users.rs
+++ b/src/model/users.rs
@@ -394,13 +394,13 @@ pub struct CurrentAccount {
 	/// When the entry was updated
 	#[serde(rename = "updated_at", with = "rfc3339")]
 	pub updated_at: OffsetDateTime,
-	/// The current avatar id
+	/// The current avatar id or empty string.
 	#[serde(default)]
 	pub current_avatar: String,
-	/// The current avatar tags
+	/// The current avatar tags or empty string.
 	#[serde(default)]
 	pub current_avatar_tags: serde_json::Value,
-	/// The fallback avatar id
+	/// The fallback avatar id or empty string.
 	#[serde(default)]
 	pub fallback_avatar: String,
 }

--- a/src/model/users.rs
+++ b/src/model/users.rs
@@ -233,8 +233,6 @@ pub struct AccountData {
 	#[serde(default)]
 	#[serde_as(as = "serde_with::NoneAsEmptyString")]
 	pub user_icon: Option<Url>,
-	/// If the user has avatar cloning on
-	pub allow_avatar_copying: bool,
 	/// When the user joined VRC
 	#[serde(rename = "date_joined", with = "crate::date_format")]
 	pub date_joined: time::Date,
@@ -426,6 +424,8 @@ pub struct User {
 	/// Base info that's shared across different user responses
 	#[serde(flatten)]
 	pub base: AccountData,
+	/// If the user has avatar cloning on
+	pub allow_avatar_copying: bool,
 	/// The friend request status with this user
 	pub friend_request_status: FriendRequestStatus,
 	/// Notes about the user

--- a/src/model/users.rs
+++ b/src/model/users.rs
@@ -233,9 +233,6 @@ pub struct AccountData {
 	#[serde(default)]
 	#[serde_as(as = "serde_with::NoneAsEmptyString")]
 	pub user_icon: Option<Url>,
-	/// When the user joined VRC
-	#[serde(rename = "date_joined", with = "crate::date_format")]
-	pub date_joined: time::Date,
 }
 
 /// Details that get added if the user is the authenticated one
@@ -426,6 +423,9 @@ pub struct User {
 	pub base: AccountData,
 	/// If the user has avatar cloning on
 	pub allow_avatar_copying: bool,
+	/// When the user joined VRC
+	#[serde(rename = "date_joined", with = "crate::date_format")]
+	pub date_joined: time::Date,
 	/// The friend request status with this user
 	pub friend_request_status: FriendRequestStatus,
 	/// Notes about the user

--- a/src/model/users.rs
+++ b/src/model/users.rs
@@ -158,6 +158,19 @@ pub struct Presence {
 	pub traveling_to_world: crate::id::OfflineOrPrivateOr<crate::id::World>,
 	/// The world that the user is in
 	pub world: crate::id::OfflineOr<String>,
+	/// If the user is rejoining the instance
+	#[serde(default)]
+	pub is_rejoining: serde_json::Value,
+	/// The current avatar tags
+	#[serde(default)]
+	pub current_avatar_tags: serde_json::Value,
+	/// URL to the user's icon, can be an empty string
+	#[serde(default)]
+	#[serde_as(as = "serde_with::NoneAsEmptyString")]
+	pub user_icon: Option<Url>,
+	/// What does this do?
+	#[serde(default)]
+	pub debugflag: serde_json::Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -166,8 +179,8 @@ pub struct Presence {
 pub struct PastDisplayName {
 	/// The display name itself
 	pub display_name: String,
-	#[serde(with = "rfc3339")]
 	/// When the entry was updated
+	#[serde(rename = "updated_at", with = "rfc3339")]
 	pub updated_at: OffsetDateTime,
 	/// If the display name change has been reverted
 	#[serde(default)]
@@ -221,6 +234,11 @@ pub struct AccountData {
 	#[serde(default)]
 	#[serde_as(as = "serde_with::NoneAsEmptyString")]
 	pub user_icon: Option<Url>,
+	/// If the user has avatar cloning on
+	pub allow_avatar_copying: bool,
+	/// When the user joined VRC
+	#[serde(rename = "date_joined", with = "crate::date_format")]
+	pub date_joined: time::Date,
 }
 
 /// Details that get added if the user is the authenticated one
@@ -231,6 +249,8 @@ pub struct CurrentAccountData {
 	/// Which version of the TOS the authenticated user has accepted
 	#[serde(rename = "acceptedTOSVersion")]
 	pub accepted_tos_version: u8,
+	/// Which version of the Privacy Policy the authenticated user has accepted
+	pub accepted_privacy_version: u8,
 	/// The URL to the current avatar's asset
 	pub current_avatar_asset_url: Url,
 	/// If the email address of the account has been verified
@@ -258,24 +278,33 @@ pub struct CurrentAccountData {
 	#[serde(default)]
 	/// Can presumably be an empty string
 	pub obfuscated_email: String,
-	#[serde(default)]
 	/// Can be an empty string
+	#[serde(default)]
 	pub obfuscated_pending_email: String,
-	/// Can be an empty string
-	#[serde(default)]
-	pub oculus_id: String,
-	#[serde(default)]
 	/// Can be empty
-	pub past_display_names: Vec<Either<PastDisplayName, String>>,
+	#[serde(default)]
+	pub past_display_names: Vec<PastDisplayName>,
 	/// If hasn't set status yet
 	pub status_first_time: bool,
 	/// History of statuses (VRC pre-populates some for new accounts)
 	pub status_history: Vec<String>,
 	/// Details of the linked steam account
 	pub steam_details: serde_json::Value,
-	#[serde(default)]
 	/// Can be empty
+	#[serde(default)]
 	pub steam_id: String,
+	/// Can be an empty string
+	#[serde(default)]
+	pub google_id: String,
+	/// Can be an empty string
+	#[serde(default)]
+	pub oculus_id: String,
+	/// Can be an empty string
+	#[serde(default)]
+	pub pico_id: String,
+	/// Can be an empty string
+	#[serde(default)]
+	pub vive_id: String,
 	/// If 2FA is enabled
 	pub two_factor_auth_enabled: bool,
 	#[serde(default)]
@@ -358,9 +387,23 @@ pub struct CurrentAccount {
 	pub offline_friends: Vec<crate::id::User>,
 	/// Friends that are online
 	pub online_friends: Vec<crate::id::User>,
+	/// Friends that are active
+	pub active_friends: Vec<crate::id::User>,
 	/// Either a date-time or empty string.
 	#[serde(rename = "last_login", with = "rfc3339")]
 	pub last_login: OffsetDateTime,
+	/// When the entry was updated
+	#[serde(rename = "updated_at", with = "rfc3339")]
+	pub updated_at: OffsetDateTime,
+	/// The current avatar id
+	#[serde(default)]
+	pub current_avatar: String,
+	/// The current avatar tags
+	#[serde(default)]
+	pub current_avatar_tags: serde_json::Value,
+	/// The fallback avatar id
+	#[serde(default)]
+	pub fallback_avatar: String,
 }
 
 /// Information that's returned about friends
@@ -384,11 +427,6 @@ pub struct User {
 	/// Base info that's shared across different user responses
 	#[serde(flatten)]
 	pub base: AccountData,
-	/// If the user has avatar cloning on
-	pub allow_avatar_copying: bool,
-	#[serde(rename = "date_joined", with = "crate::date_format")]
-	/// When the user joined VRC
-	pub date_joined: time::Date,
 	/// The friend request status with this user
 	pub friend_request_status: FriendRequestStatus,
 	/// Notes about the user

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -7,7 +7,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn current_user() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::GetCurrentUser;
 	let current_user: vrc::model::CurrentAccount =

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -7,7 +7,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn current_user() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::GetCurrentUser;
 	let current_user: vrc::model::CurrentAccount =

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 use once_cell::sync::Lazy;
+use racal::reqwest::ApiError;
 use vrc::{api_client::AuthenticatedVRC, query::Authentication};
 
 const USER_AGENT: &str = concat!(
@@ -42,6 +43,6 @@ pub static USER_AUTH: Lazy<Authentication> = Lazy::new(|| {
 	user_auth
 });
 
-pub fn api_client() -> Result<AuthenticatedVRC> {
-	AuthenticatedVRC::new(USER_AGENT.to_owned(), USER_AUTH.clone())?
+pub fn api_client() -> Result<AuthenticatedVRC, ApiError> {
+	AuthenticatedVRC::new(USER_AGENT.to_owned(), USER_AUTH.clone())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -42,6 +42,6 @@ pub static USER_AUTH: Lazy<Authentication> = Lazy::new(|| {
 	user_auth
 });
 
-pub fn api_client() -> AuthenticatedVRC {
-	AuthenticatedVRC::new(USER_AGENT.to_owned(), USER_AUTH.clone()).unwrap()
+pub fn api_client() -> Result<AuthenticatedVRC> {
+	AuthenticatedVRC::new(USER_AGENT.to_owned(), USER_AUTH.clone())?
 }

--- a/tests/friends.rs
+++ b/tests/friends.rs
@@ -7,7 +7,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn friends() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let mut query = vrc::query::ListFriends::default();
 	query.pagination.limit = 1;

--- a/tests/instances.rs
+++ b/tests/instances.rs
@@ -10,7 +10,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn active_instance() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let mut query = vrc::query::ActiveWorlds::default();
 	query.pagination.limit = 1;

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -7,7 +7,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn user_tupper() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::User {
 		id: "usr_c1644b5b-3ca4-45b4-97c6-a2a0de70d469".parse().unwrap(),
@@ -26,7 +26,7 @@ async fn user_tupper() -> Result<(), ApiError> {
 #[tokio::test]
 #[ignore]
 async fn user_system() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::User { id: "vF8OwsCETo".parse().unwrap() };
 	let user: vrc::model::AnyUser = api_client.query(query).await?;
@@ -57,7 +57,7 @@ async fn user_self() -> Result<(), ApiError> {
 		None => return Ok(()),
 	};
 
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::User { id: friend_id.to_owned() };
 	let user: vrc::model::AnyUser = api_client.query(query).await?;
@@ -88,7 +88,7 @@ async fn user_friend() -> Result<(), ApiError> {
 		None => return Ok(()),
 	};
 
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::User { id: friend_id.to_owned() };
 	let user: vrc::model::AnyUser = api_client.query(query).await?;

--- a/tests/worlds.rs
+++ b/tests/worlds.rs
@@ -10,7 +10,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 async fn active_worlds() -> Result<(), ApiError> {
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::ActiveWorlds::default();
 	let active_worlds: Vec<WorldListing> = api_client.query(query).await?;
@@ -30,7 +30,7 @@ async fn world() -> Result<(), ApiError> {
 		None => return Ok(()),
 	};
 
-	let api_client = common::api_client();
+	let api_client = common::api_client()?;
 
 	let query = vrc::query::World { id: world_id.clone() };
 	let world: World = api_client.query(query).await?;


### PR DESCRIPTION
This requires merging https://github.com/onlivfe/racal/pull/2 first.

I formatted and updated the cargo dependencies.
I also removed the unneeded minor version numbers from post-v1 dependencies since they aren't used to lock to a minor version without an `=` prefix, only for pre-v1 packages.